### PR TITLE
Update index.html

### DIFF
--- a/priv/assets/index.html
+++ b/priv/assets/index.html
@@ -71,8 +71,8 @@
             <div data-w-tab="Tab 1" class="w-tab-pane">
               <div class="paragraph-9">Via curl:</div>
               <div class="code_block-2">
-                <div class="text-block-21">sh -c &quot;$(sh -c "$(curl -fsSL
-                  https://raw.githubusercontent.com/novaframework/<br>rebar3_nova/master/install.sh)")&quot;</div>
+                <div class="text-block-21">sh -c "$(curl -fsSL 
+                  https://raw.githubusercontent.com/novaframework/rebar3_nova/master/install.sh)"</div>
               </div>
             </div>
             <div data-w-tab="Tab 2" class="w-tab-pane">


### PR DESCRIPTION
the curl way returned an error because of double `sh -c`  It was: 

```
sh -c "$(sh -c "$(curl -fsSL https://raw.githubusercontent.com/novaframework/rebar3_nova/master/install.sh)")"
```

Now it is:

```
sh -c "$(curl -fsSL https://raw.githubusercontent.com/novaframework/rebar3_nova/master/install.sh)"
```
As in the Github repo