### PR TITLE
Adjust z-index to 10000 for small screens

### DIFF
--- a/priv/assets/css/novaframework.webflow.css
+++ b/priv/assets/css/novaframework.webflow.css
@@ -5559,7 +5559,7 @@
   }
 
   .navbar-5 {
-    z-index: 1000;
+    z-index: 10000;
     padding-right: 4px;
     padding-left: 24px;
     border-bottom-width: 1px;
@@ -7048,7 +7048,7 @@
   }
 
   .navbar-5 {
-    z-index: 10;
+    z-index: 10000;
     clear: right;
     background-color: #1f1a39;
     background-clip: border-box;


### PR DESCRIPTION
Issue: https://erlanger.slack.com/archives/CM7T2450D/p1715299286725379

The hero image is set to 9999, so the nav bar needs to be 1 higher than that. Feel free to close this if it was intended.

I can add a before and after video tomorrow.