### PR TITLE
Adjust some styling for nav-menu

### DIFF
--- a/priv/assets/css/novaframework.webflow.css
+++ b/priv/assets/css/novaframework.webflow.css
@@ -923,9 +923,9 @@
   /* margin-top: 20px; */
   background-color: #4466;
   width: 100%;
-  height: 4em;
-  border-top: 1px solid #FFF;
+  padding-bottom: 10px;
   border-bottom: 1px solid #FFF;
+  background-color: #1f1a39;
 }
 
 .brand {
@@ -5483,11 +5483,6 @@
     background-color: #fafafa;
   }
 
-  .nav-menu {
-    border-top: 1px solid #dfe0e2;
-    background-color: #f5f6fa;
-  }
-
   .navbar {
     padding-right: 4px;
     padding-left: 24px;
@@ -6321,10 +6316,6 @@
     background-color: #fafafa;
   }
 
-  .nav-menu {
-    background-color: #1f1a39;
-  }
-
   .brand {
     padding-left: 0px;
   }
@@ -6927,9 +6918,6 @@
     -webkit-flex: 0 auto;
     -ms-flex: 0 auto;
     flex: 0 auto;
-    border-bottom: 1px solid #f5f6fa;
-    border-top-style: none;
-    background-color: #1f1a39;
     text-align: center;
   }
 


### PR DESCRIPTION
Experimenting a bit. 

- The height for the nav-menu was set to `4em` so it would not contain the menu entries
- The nav-menu background was set to near-white for one screen size
- Removed the top border (I think it looks okay but I am not a designer)
- The Nova logo doesn't align well with the Releases button so I added some padding (looks fine for smaller screens) 

Some screenshots

<img width="583" alt="Screenshot 2024-05-19 at 3 13 25 PM" src="https://github.com/novaframework/nova_page/assets/3086255/dd740b3f-7279-4a5b-8ce1-37e1529be592">

^ this one seems okay?

<img width="1248" alt="Screenshot 2024-05-19 at 3 08 15 PM" src="https://github.com/novaframework/nova_page/assets/3086255/e7756561-da7b-4c77-bfb9-2b7c2c98f022">

<img width="369" alt="Screenshot 2024-05-19 at 3 07 59 PM" src="https://github.com/novaframework/nova_page/assets/3086255/6e2e9bbb-f78b-49be-ba74-db86bd5f8dce">

<img width="772" alt="Screenshot 2024-05-19 at 3 07 43 PM" src="https://github.com/novaframework/nova_page/assets/3086255/a541afa3-5032-4076-8410-84a21f841883">

