### PR TITLE
chore: migrate to shared erlang-ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,41 +6,10 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
-
 jobs:
   ci:
-    name: OTP ${{ matrix.otp }}
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        otp: ['27.2', '28.0']
-        rebar3: ['3.24']
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{ matrix.otp }}
-          rebar3-version: ${{ matrix.rebar3 }}
-
-      - name: Cache _build
-        uses: actions/cache@v4
-        with:
-          path: |
-            _build
-            ~/.cache/rebar3
-          key: ${{ runner.os }}-otp-${{ matrix.otp }}-rebar3-${{ matrix.rebar3 }}-${{ hashFiles('rebar.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-otp-${{ matrix.otp }}-rebar3-${{ matrix.rebar3 }}-
-
-      - name: Compile
-        run: rebar3 compile
-
-      - name: Xref
-        run: rebar3 xref
-
-      - name: Dialyzer
-        run: rebar3 dialyzer
+    uses: Taure/erlang-ci/.github/workflows/ci.yml@v1
+    with:
+      enable-eunit: false
+      enable-fmt: false
+      enable-audit: true


### PR DESCRIPTION
Replace inline CI with Taure/erlang-ci reusable workflow. Enables audit.